### PR TITLE
fix: plugin.default is not a function

### DIFF
--- a/playwright-ct-angular/index.js
+++ b/playwright-ct-angular/index.js
@@ -24,7 +24,12 @@ function plugin() {
   const { createPlugin } = require('@playwright/experimental-ct-core/lib/vitePlugin');
   return createPlugin(
     path.join(__dirname, 'registerSource.mjs'),
-    () => import('@analogjs/vite-plugin-angular').then(plugin => plugin.default({ jit: false }))
+    () => import('@analogjs/vite-plugin-angular').then(plugin => {
+      // TODO: remove the typeof plugin.default check
+      if (typeof plugin.default === 'function')
+        return plugin.default({ jit: false })
+      return plugin.default.default({ jit: false })
+    })
   )
 };
 


### PR DESCRIPTION
Partial fix for: https://github.com/sand4rt/playwright-ct-angular/issues/23

Seems related to:
- https://github.com/analogjs/analog/pull/598
- https://github.com/analogjs/analog/pull/582
- https://github.com/analogjs/analog/issues/573